### PR TITLE
Actually update the module to dnd5e 3.0.4

### DIFF
--- a/module.json
+++ b/module.json
@@ -49,7 +49,7 @@
         "type": "system",
         "compatibility": {
           "minimum": "2.4.0",
-          "maximum": "2.4.9"
+          "maximum": "3.0.4"
         }
       }
     ],


### PR DESCRIPTION
The main page on https://foundryvtt.com/packages/items-with-spells-5e shows that version 11.1.2 supports up to dnd5e version 3.0.4... but it can't be enabled because this line wasn't changed. This fixes the issue and we can actually enable it in our game now.